### PR TITLE
Add support for 1.20.3 and 1.20.4

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -12,6 +12,7 @@
         <option value="$PROJECT_DIR$/pom.xml" />
       </list>
     </option>
+    <option name="workspaceImportForciblyTurnedOn" value="true" />
   </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_18" default="true" project-jdk-name="12" project-jdk-type="JavaSDK" />
 </project>

--- a/1_20_R2/pom.xml
+++ b/1_20_R2/pom.xml
@@ -1,0 +1,44 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>BeaconWaypoints</artifactId>
+        <groupId>com.github.dawsonvilamaa</groupId>
+        <version>1.6.4</version>
+    </parent>
+
+    <artifactId>1_20_R2</artifactId>
+
+    <repositories>
+        <repository>
+            <id>spigot-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot</artifactId>
+            <version>1.20.2-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.dawsonvilamaa</groupId>
+            <artifactId>core</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.dawsonvilamaa</groupId>
+            <artifactId>VersionWrapper</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+    </properties>
+</project>

--- a/1_20_R3/pom.xml
+++ b/1_20_R3/pom.xml
@@ -1,0 +1,44 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>BeaconWaypoints</artifactId>
+        <groupId>com.github.dawsonvilamaa</groupId>
+        <version>1.6.4</version>
+    </parent>
+
+    <artifactId>1_20_R3</artifactId>
+
+    <repositories>
+        <repository>
+            <id>spigot-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot</artifactId>
+            <version>1.20.4-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.dawsonvilamaa</groupId>
+            <artifactId>core</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.dawsonvilamaa</groupId>
+            <artifactId>VersionWrapper</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+    </properties>
+</project>

--- a/1_20_R3/src/main/java/com/github/dawsonvilamaa/beaconwaypoint/version/Version_1_20_R3.java
+++ b/1_20_R3/src/main/java/com/github/dawsonvilamaa/beaconwaypoint/version/Version_1_20_R3.java
@@ -1,0 +1,54 @@
+package com.github.dawsonvilamaa.beaconwaypoint.version;
+
+import net.minecraft.core.BlockPosition;
+import net.minecraft.core.EnumDirection;
+import net.minecraft.server.level.EntityPlayer;
+import net.minecraft.world.EnumHand;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.context.BlockActionContext;
+import net.minecraft.world.level.World;
+import net.minecraft.world.level.block.state.IBlockData;
+import net.minecraft.world.phys.MovingObjectPositionBlock;
+import net.minecraft.world.phys.Vec3D;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.craftbukkit.v1_20_R3.block.CraftBlock;
+import org.bukkit.craftbukkit.v1_20_R3.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class Version_1_20_R3 implements VersionWrapper{
+    /**
+     * Opens the vanilla beacon GUI for a player
+     *
+     * @param beacon
+     * @param player
+     */
+    @Override
+    public void openBeaconMenu(Block beacon, Player player) {
+        Location beaconLoc = beacon.getLocation();
+        Vec3D blockLocVec3D = new Vec3D(beaconLoc.getBlockX(), beaconLoc.getBlockY(), beaconLoc.getBlockZ());
+        BlockPosition blockPosition = new BlockPosition(beaconLoc.getBlockX(), beaconLoc.getBlockY(), beaconLoc.getBlockZ());
+        EntityPlayer playerHandle = ((CraftPlayer) player).getHandle();
+        net.minecraft.world.level.block.Block beaconHandle = ((CraftBlock) beacon).getNMS().b(); //b(): getBlock()
+        ItemStack itemStackHandle = playerHandle.fS().f(); //fN().f(): getInventory().getSelected()
+        MovingObjectPositionBlock blockHitResult = new MovingObjectPositionBlock(blockLocVec3D, EnumDirection.b, blockPosition, true); //EnumDirection.b: EnumDirection.UP
+        BlockActionContext blockPlaceContext = new BlockActionContext(playerHandle, EnumHand.a, itemStackHandle, blockHitResult); //EnumHand.a: EnumHand.MAIN_HAND
+        IBlockData blockState = beaconHandle.a(blockPlaceContext); //a(): getPlacedState()
+        World levelHandle = playerHandle.dM(); //x(): getWorld()
+        beaconHandle.a(blockState, levelHandle, blockPosition, playerHandle, EnumHand.a, blockHitResult); //a(): interact(), EnumHand.a: EnumHand.MAIN_HAND
+    }
+
+    /**
+     * Returns the blocks available to be used in a beacon pyramid
+     *
+     * @return
+     */
+    @Override
+    public List<Material> getPyramidBlocks() {
+        return Arrays.asList(Material.IRON_BLOCK, Material.GOLD_BLOCK, Material.DIAMOND_BLOCK, Material.EMERALD_BLOCK, Material.NETHERITE_BLOCK);
+    }
+}

--- a/Build/pom.xml
+++ b/Build/pom.xml
@@ -102,6 +102,12 @@
             <version>${project.parent.version}</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.dawsonvilamaa</groupId>
+            <artifactId>1_20_R3</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/dependency-reduced-pom.xml
+++ b/core/dependency-reduced-pom.xml
@@ -44,6 +44,18 @@
       <id>paper-repo</id>
       <url>https://papermc.io/repo/repository/maven-public/</url>
     </repository>
+    <repository>
+      <id>md_5-snapshots</id>
+      <url>https://repo.md-5.net/content/repositories/snapshots/</url>
+    </repository>
+    <repository>
+      <id>md_5-releases</id>
+      <url>https://repo.md-5.net/content/repositories/releases/</url>
+    </repository>
+    <repository>
+      <id>spigot-repo</id>
+      <url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
+    </repository>
   </repositories>
   <dependencies>
     <dependency>
@@ -67,7 +79,7 @@
     <dependency>
       <groupId>org.bstats</groupId>
       <artifactId>bstats-bukkit</artifactId>
-      <version>3.0.0</version>
+      <version>3.0.2</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -18,6 +18,18 @@
             <id>paper-repo</id>
             <url>https://papermc.io/repo/repository/maven-public/</url>
         </repository>
+        <repository>
+            <id>md_5-snapshots</id>
+            <url>https://repo.md-5.net/content/repositories/snapshots/</url>
+        </repository>
+        <repository>
+            <id>md_5-releases</id>
+            <url>https://repo.md-5.net/content/repositories/releases/</url>
+        </repository>
+        <repository>
+            <id>spigot-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -42,7 +54,7 @@
         <dependency>
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <module>1_19_R3</module>
         <module>1_20_R1</module>
         <module>1_20_R2</module>
+        <module>1_20_R3</module>
         <module>Build</module>
     </modules>
 


### PR DESCRIPTION
I've added NMS support for 1.20.3 and 1.20.4 (1_20_R3). I based the updated off the commit for 1.20.2, but I may have missed some files that need changes. I have tested it on a 1.20.4 server and opening the beacon effects page works. The plugin's version was not changed, feel free to add the required stuff to my PR.